### PR TITLE
Make abbreviation optional

### DIFF
--- a/classes/region.py
+++ b/classes/region.py
@@ -1,7 +1,8 @@
 import dataclasses
+from typing import Optional
 
 @dataclasses.dataclass
 class Region:
     id: int
     name: str
-    abbreviation: str
+    abbreviation: Optional[str]


### PR DESCRIPTION
I tried running the example script but I got this error: `dacite.exceptions.MissingValueError: missing value for field "user.hometown.region.abbreviation"`.
I inspect the response and it turns out `region` doesn't have the `abbreviation` field anymore, so I made it optional
